### PR TITLE
Add Android Plurals support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ class App : Application() {
 }
 
 object MyPhilologyRepositoryFactory : PhilologyRepositoryFactory {
-    override fun getPhilologyRepository(locale: Locale): PhilologyRepository? = when{
+    override fun getPhilologyRepository(locale: Locale): PhilologyRepository? = when {
         Locale.ENGLISH.language  == locale.language -> EnglishPhilologyRepository
         Locale("es", "ES").language == locale.language -> SpanishPhilologyRepository
 // If we don't support a language we could return null as PhilologyRepository and
@@ -63,8 +63,16 @@ object MyPhilologyRepositoryFactory : PhilologyRepositoryFactory {
 }
 
 object EnglishPhilologyRepository : PhilologyRepository {
-    override fun getText(key: String): CharSequence? = when (key) {
-        "label" -> "New value for the `label` key, it could be fetched from a database or an external API server"
+    override fun getText(resource: Resource): CharSequence? = when (resource) {
+        is Text -> when (resource.key) {
+            "label" -> "New value for the `label` key, it could be fetched from a database or an external API server"
+            else -> null
+        }
+        is Plural -> when ("${resource.key}_${resource.quantityKeyword}") {
+            "plurals_label_one" -> "New value for the `plurals_label` key and `one` quantity keyword"
+            "plurals_label_other" -> "New value for the `plurals_label` key and `other` quantity keyword"
+            else -> null
+        }
 // If we don't want reword an strings we could return null and the value from the string resources file will be used
         else -> null
     }
@@ -99,7 +107,7 @@ public class MyPhilologyRepositoryFactory extends PhilologyRepositoryFactory {
 public class EnglishPhilologyRepository extends PhilologyRepository {
     @Nullable
     @Override
-    public CharSequence getText(@NotNull String key) { /* Implementation */}
+    public CharSequence getText(@NotNull Resource resource) { /* Implementation */}
 }
 ```
 

--- a/buildSrc/src/main/groovy/com/jcminarro/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/com/jcminarro/Dependencies.groovy
@@ -13,6 +13,7 @@ class Dependencies {
     private static String KLUENT_VERSION = '1.28'
     private static String MOKITO_KOTLIN_VERSION = '1.5.0'
     private static String VIEW_PUMP_VERSION = '1.0.0'
+    private static String ICU4J_VERSION = '64.2'
 
     static final String kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
     static final String androidBuildToolGradlePlugin = "com.android.tools.build:gradle:$ANDROID_BUILD_TOOL_VERSION"
@@ -27,4 +28,5 @@ class Dependencies {
     static final String kluent = "org.amshove.kluent:kluent:$KLUENT_VERSION"
     static final String mockitoKotlin = "com.nhaarman:mockito-kotlin:$MOKITO_KOTLIN_VERSION"
     static final String viewPump = "io.github.inflationx:viewpump:$VIEW_PUMP_VERSION"
+    static final String icu4j = "com.ibm.icu:icu4j:$ICU4J_VERSION"
 }

--- a/philology/build.gradle
+++ b/philology/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation Dependencies.kotlinSTDLib
     implementation Dependencies.appCompat
     implementation Dependencies.viewPump
+    implementation Dependencies.icu4j
 
     testImplementation Dependencies.robolectric
     testImplementation Dependencies.jUnit

--- a/philology/src/main/java/com/jcminarro/philology/Philology.kt
+++ b/philology/src/main/java/com/jcminarro/philology/Philology.kt
@@ -48,7 +48,7 @@ interface ViewTransformerFactory {
 }
 
 private val emptyPhilologyRepository = object : PhilologyRepository{
-    override fun getText(key: String): CharSequence? = null
+    override fun getText(resource: Resource): CharSequence? = null
 }
 
 private val emptyViewTransformerFactory = object : ViewTransformerFactory {

--- a/philology/src/main/java/com/jcminarro/philology/PhilologyResources.kt
+++ b/philology/src/main/java/com/jcminarro/philology/PhilologyResources.kt
@@ -9,4 +9,13 @@ internal class PhilologyResources(baseResources: Resources)
 
     override fun getText(id: Int): CharSequence = resourcesUtil.getText(id)
     override fun getString(id: Int): String = resourcesUtil.getString(id)
+    override fun getQuantityText(id: Int, quantity: Int): CharSequence {
+        return resourcesUtil.getQuantityText(id, quantity)
+    }
+    override fun getQuantityString(id: Int, quantity: Int): String {
+        return resourcesUtil.getQuantityString(id, quantity)
+    }
+    override fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String {
+        return resourcesUtil.getQuantityString(id, quantity, *formatArgs)
+    }
 }

--- a/philology/src/main/java/com/jcminarro/philology/PhilologyResources.kt
+++ b/philology/src/main/java/com/jcminarro/philology/PhilologyResources.kt
@@ -9,13 +9,10 @@ internal class PhilologyResources(baseResources: Resources)
 
     override fun getText(id: Int): CharSequence = resourcesUtil.getText(id)
     override fun getString(id: Int): String = resourcesUtil.getString(id)
-    override fun getQuantityText(id: Int, quantity: Int): CharSequence {
-        return resourcesUtil.getQuantityText(id, quantity)
-    }
-    override fun getQuantityString(id: Int, quantity: Int): String {
-        return resourcesUtil.getQuantityString(id, quantity)
-    }
-    override fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String {
-        return resourcesUtil.getQuantityString(id, quantity, *formatArgs)
-    }
+    override fun getQuantityText(id: Int, quantity: Int): CharSequence =
+        resourcesUtil.getQuantityText(id, quantity)
+    override fun getQuantityString(id: Int, quantity: Int): String =
+        resourcesUtil.getQuantityString(id, quantity)
+    override fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String =
+        resourcesUtil.getQuantityString(id, quantity, *formatArgs)
 }

--- a/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
+++ b/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
@@ -20,22 +20,19 @@ internal class ResourcesUtil(private val baseResources: Resources) {
     fun getString(id: Int): String = getText(id).toString()
 
     @Throws(Resources.NotFoundException::class)
-    fun getQuantityText(id: Int, quantity: Int): CharSequence {
-        return repository.getText(
-            Resource.Plural(
-                baseResources.getResourceEntryName(id),
-                quantity.toPluralKeyword(baseResources.currentLocale())
-            )
-        ) ?: baseResources.getQuantityText(id, quantity)
-    }
+    fun getQuantityText(id: Int, quantity: Int): CharSequence = repository.getText(
+        Resource.Plural(
+            baseResources.getResourceEntryName(id),
+            quantity.toPluralKeyword(baseResources.currentLocale())
+        )
+    ) ?: baseResources.getQuantityText(id, quantity)
 
     @Throws(Resources.NotFoundException::class)
     fun getQuantityString(id: Int, quantity: Int): String = getQuantityText(id, quantity).toString()
 
     @Throws(Resources.NotFoundException::class)
-    fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String {
-        return String.format(getQuantityString(id, quantity), *formatArgs)
-    }
+    fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String =
+        String.format(getQuantityString(id, quantity), *formatArgs)
 }
 
 interface PhilologyRepository {

--- a/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
+++ b/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
@@ -2,6 +2,7 @@ package com.jcminarro.philology
 
 import android.content.res.Resources
 import android.os.Build
+import com.ibm.icu.text.PluralRules
 import java.util.Locale
 
 internal class ResourcesUtil(private val baseResources: Resources) {
@@ -11,15 +12,39 @@ internal class ResourcesUtil(private val baseResources: Resources) {
 
     @Throws(Resources.NotFoundException::class)
     fun getText(id: Int): CharSequence {
-        return repository.getText(baseResources.getResourceEntryName(id)) ?: baseResources.getText(id)
+        return repository.getText(Resource.Text(baseResources.getResourceEntryName(id)))
+            ?: baseResources.getText(id)
     }
 
     @Throws(Resources.NotFoundException::class)
     fun getString(id: Int): String = getText(id).toString()
+
+    @Throws(Resources.NotFoundException::class)
+    fun getQuantityText(id: Int, quantity: Int): CharSequence {
+        return repository.getText(
+            Resource.Plural(
+                baseResources.getResourceEntryName(id),
+                quantity.toPluralKeyword(baseResources.currentLocale())
+            )
+        ) ?: baseResources.getQuantityText(id, quantity)
+    }
+
+    @Throws(Resources.NotFoundException::class)
+    fun getQuantityString(id: Int, quantity: Int): String = getQuantityText(id, quantity).toString()
+
+    @Throws(Resources.NotFoundException::class)
+    fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String {
+        return String.format(getQuantityString(id, quantity), *formatArgs)
+    }
 }
 
 interface PhilologyRepository {
-    fun getText(key: String): CharSequence?
+    fun getText(resource: Resource): CharSequence?
+}
+
+sealed class Resource(open val key: String) {
+    data class Text(override val key: String) : Resource(key)
+    data class Plural(override val key: String, val quantityKeyword: String) : Resource(key)
 }
 
 @SuppressWarnings("NewApi")
@@ -28,4 +53,8 @@ private fun Resources.currentLocale(): Locale = if (Build.VERSION.SDK_INT <= Bui
     configuration.locale
 } else {
     configuration.locales[0]
+}
+
+private fun Int.toPluralKeyword(locale: Locale): String {
+    return PluralRules.forLocale(locale).select(this.toDouble())
 }

--- a/philology/src/test/java/com/jcminarro/philology/Mother.kt
+++ b/philology/src/test/java/com/jcminarro/philology/Mother.kt
@@ -4,6 +4,9 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.LocaleList
 import android.util.AttributeSet
+import com.ibm.icu.impl.number.DecimalQuantity
+import com.jcminarro.philology.Resource.Plural
+import com.jcminarro.philology.Resource.Text
 import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.doThrow
@@ -20,16 +23,25 @@ fun createConfiguration(locale: Locale = Locale.ENGLISH): Configuration = mock<C
     When calling this.locales doReturn LocaleList(locale)
 }
 
-fun configureResourceGetText(resources: Resources,
-                             id: Int,
-                             nameId: String,
-                             text: CharSequence) {
+fun configureResourceGetText(
+    resources: Resources,
+    id: Int,
+    nameId: String,
+    text: CharSequence
+) {
     When calling resources.getResourceEntryName(id) doReturn nameId
     When calling resources.getText(id) doReturn text
 }
 
-fun configureResourceGetTextException(resources: Resources, id: Int) {
+fun configureResourceGetIdException(resources: Resources, id: Int) {
     When calling resources.getResourceEntryName(id) doThrow Resources.NotFoundException()
+}
+
+fun configureResourceGetQuantityText(
+    resources: Resources, id: Int, nameId: String, quantity: Int, text: CharSequence
+) {
+    When calling resources.getResourceEntryName(id) doReturn nameId
+    When calling resources.getQuantityText(id, quantity) doReturn text
 }
 
 fun clearPhilology() {
@@ -38,29 +50,38 @@ fun clearPhilology() {
     })
 }
 
-fun createRepository(nameId: String, text: CharSequence): PhilologyRepository =
-        object : PhilologyRepository {
-            override fun getText(key: String): CharSequence? = text.takeIf {key == nameId}
+fun createRepository(nameId: String, quantity: String?, text: CharSequence): PhilologyRepository =
+    object : PhilologyRepository {
+        override fun getText(resource: Resource): CharSequence? = when (resource) {
+            is Text -> text.takeIf { resource.key == nameId }
+            is Plural -> text.takeIf {
+                resource.key == nameId && resource.quantityKeyword == quantity
+            }
         }
+    }
 
 fun createFactory(vararg repositoryPairs: Pair<Locale, PhilologyRepository>): PhilologyRepositoryFactory =
-        object : PhilologyRepositoryFactory {
-            override fun getPhilologyRepository(locale: Locale): PhilologyRepository? =
-                    repositoryPairs.firstOrNull {it.first == locale}?.second
-        }
+    object : PhilologyRepositoryFactory {
+        override fun getPhilologyRepository(locale: Locale): PhilologyRepository? =
+            repositoryPairs.firstOrNull { it.first == locale }?.second
+    }
 
 fun configurePhilology(repository: PhilologyRepository, locale: Locale = Locale.ENGLISH) {
     Philology.init(createFactory(locale to repository))
 }
 
 fun createAttributeSet(vararg attributeType: AttributeType): AttributeSet = mock<AttributeSet>().apply {
-    attributeType.forEachIndexed {index, at ->
+    attributeType.forEachIndexed { index, at ->
         when (at) {
             is HardcodedAttribute -> {
-                Mockito.`when`(this.getAttributeResourceValue(eq(index), org.amshove.kluent.any())).doAnswer {it.arguments[1] as Int}
+                Mockito.`when`(this.getAttributeResourceValue(eq(index), org.amshove.kluent.any()))
+                    .doAnswer { it.arguments[1] as Int }
             }
             is ResourceIdAttribute -> {
-                When calling this.getAttributeResourceValue(eq(index), org.amshove.kluent.any()) doReturn index
+                When calling this.getAttributeResourceValue(
+                    eq(index),
+                    org.amshove.kluent.any()
+                ) doReturn index
             }
         }
         When calling this.getAttributeName(index) doReturn at.key
@@ -68,8 +89,9 @@ fun createAttributeSet(vararg attributeType: AttributeType): AttributeSet = mock
     When calling this.attributeCount doReturn attributeType.size
 }
 
-sealed class AttributeType{
+sealed class AttributeType {
     abstract val key: String
 }
+
 data class HardcodedAttribute(override val key: String) : AttributeType()
 data class ResourceIdAttribute(override val key: String) : AttributeType()

--- a/philology/src/test/java/com/jcminarro/philology/PhilologyResourcesTest.kt
+++ b/philology/src/test/java/com/jcminarro/philology/PhilologyResourcesTest.kt
@@ -30,7 +30,7 @@ class PhilologyResourcesTest {
 
     @Test(expected = Resources.NotFoundException::class)
     fun `Should throw an exception if the given id doesn't exit asking for a text`() {
-        configureResourceGetTextException(baseResources, id)
+        configureResourceGetIdException(baseResources, id)
         resources.getText(id)
     }
 
@@ -42,7 +42,7 @@ class PhilologyResourcesTest {
 
     @Test(expected = Resources.NotFoundException::class)
     fun `Should throw an exception if the given id doesn't exit asking for an String`() {
-        configureResourceGetTextException(baseResources, id)
+        configureResourceGetIdException(baseResources, id)
         resources.getString(id)
     }
 
@@ -55,14 +55,14 @@ class PhilologyResourcesTest {
     @Test()
     fun `Should return a CharSecuence from repository asking for a text`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
-        configurePhilology(createRepository(nameId, repoCharSequence))
+        configurePhilology(createRepository(nameId, null, repoCharSequence))
         resources.getText(id) `should equal` repoCharSequence
     }
 
     @Test()
     fun `Should return a CharSecuence from repository asking for an String`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
-        configurePhilology(createRepository(nameId, repoCharSequence))
+        configurePhilology(createRepository(nameId, null, repoCharSequence))
         resources.getString(id) `should equal` repoString
     }
 }

--- a/philology/src/test/java/com/jcminarro/philology/PhilologyResourcesTest.kt
+++ b/philology/src/test/java/com/jcminarro/philology/PhilologyResourcesTest.kt
@@ -29,38 +29,38 @@ class PhilologyResourcesTest {
     }
 
     @Test(expected = Resources.NotFoundException::class)
-    fun `Should throw an exception if the given id doesn't exit asking for a text`() {
+    fun `Should throw an exception if the given id doesn't exist asking for a text`() {
         configureResourceGetIdException(baseResources, id)
         resources.getText(id)
     }
 
     @Test()
-    fun `Should return a CharSecuence asking for a text`() {
+    fun `Should return a CharSequence asking for a text`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
         resources.getText(id) `should equal` someCharSequence
     }
 
     @Test(expected = Resources.NotFoundException::class)
-    fun `Should throw an exception if the given id doesn't exit asking for an String`() {
+    fun `Should throw an exception if the given id doesn't exist asking for an String`() {
         configureResourceGetIdException(baseResources, id)
         resources.getString(id)
     }
 
     @Test()
-    fun `Should return a CharSecuence asking for an String`() {
+    fun `Should return a CharSequence asking for an String`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
         resources.getString(id) `should equal` someString
     }
 
     @Test()
-    fun `Should return a CharSecuence from repository asking for a text`() {
+    fun `Should return a CharSequence from repository asking for a text`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
         configurePhilology(createRepository(nameId, null, repoCharSequence))
         resources.getText(id) `should equal` repoCharSequence
     }
 
     @Test()
-    fun `Should return a CharSecuence from repository asking for an String`() {
+    fun `Should return a CharSequence from repository asking for an String`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
         configurePhilology(createRepository(nameId, null, repoCharSequence))
         resources.getString(id) `should equal` repoString

--- a/philology/src/test/java/com/jcminarro/philology/PhilologyVectorEnabledTintResourcesTest.kt
+++ b/philology/src/test/java/com/jcminarro/philology/PhilologyVectorEnabledTintResourcesTest.kt
@@ -32,7 +32,7 @@ class PhilologyVectorEnabledTintResourcesTest {
 
     @Test(expected = Resources.NotFoundException::class)
     fun `Should throw an exception if the given id doesn't exit asking for a text`() {
-        configureResourceGetTextException(baseResources, id)
+        configureResourceGetIdException(baseResources, id)
         resources.getText(id)
     }
 
@@ -44,7 +44,7 @@ class PhilologyVectorEnabledTintResourcesTest {
 
     @Test(expected = Resources.NotFoundException::class)
     fun `Should throw an exception if the given id doesn't exit asking for an String`() {
-        configureResourceGetTextException(baseResources, id)
+        configureResourceGetIdException(baseResources, id)
         resources.getString(id)
     }
 
@@ -57,14 +57,14 @@ class PhilologyVectorEnabledTintResourcesTest {
     @Test()
     fun `Should return a CharSecuence from repository asking for a text`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
-        configurePhilology(createRepository(nameId, repoCharSequence))
+        configurePhilology(createRepository(nameId, null, repoCharSequence))
         resources.getText(id) `should equal` repoCharSequence
     }
 
     @Test()
     fun `Should return a CharSecuence from repository asking for an String`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
-        configurePhilology(createRepository(nameId, repoCharSequence))
+        configurePhilology(createRepository(nameId, null, repoCharSequence))
         resources.getString(id) `should equal` repoString
     }
 }

--- a/philology/src/test/java/com/jcminarro/philology/ResourcesUtilTest.kt
+++ b/philology/src/test/java/com/jcminarro/philology/ResourcesUtilTest.kt
@@ -20,6 +20,8 @@ class ResourcesUtilTest {
     private val repoCharSequence: CharSequence = "repo"
     private val repoString: String = repoCharSequence.toString()
     private val id = 0
+    private val quantity = 1
+    private val formatArg = "argument"
     private val nameId = "nameId"
 
     @Before
@@ -29,40 +31,90 @@ class ResourcesUtilTest {
     }
 
     @Test(expected = Resources.NotFoundException::class)
-    fun `Should throw an exception if the given id doesn't exit asking for a text`() {
-        configureResourceGetTextException(baseResources, id)
+    fun `Should throw an exception if the given id doesn't exist asking for a text`() {
+        configureResourceGetIdException(baseResources, id)
         resources.getText(id)
     }
 
-    @Test()
-    fun `Should return a CharSecuence asking for a text`() {
+    @Test
+    fun `Should return a CharSequence asking for a text`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
         resources.getText(id) `should equal` someCharSequence
     }
 
     @Test(expected = Resources.NotFoundException::class)
-    fun `Should throw an exception if the given id doesn't exit asking for an String`() {
-        configureResourceGetTextException(baseResources, id)
+    fun `Should throw an exception if the given id doesn't exist asking for an String`() {
+        configureResourceGetIdException(baseResources, id)
         resources.getString(id)
     }
 
-    @Test()
-    fun `Should return a CharSecuence asking for an String`() {
+    @Test
+    fun `Should return a CharSequence asking for an String`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
         resources.getString(id) `should equal` someString
     }
 
-    @Test()
-    fun `Should return a CharSecuence from repository asking for a text`() {
+    @Test
+    fun `Should return a CharSequence from repository asking for a text`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
-        configurePhilology(createRepository(nameId, repoCharSequence))
+        configurePhilology(createRepository(nameId, null, repoCharSequence))
         resources.getText(id) `should equal` repoCharSequence
     }
 
-    @Test()
-    fun `Should return a CharSecuence from repository asking for an String`() {
+    @Test
+    fun `Should return a CharSequence from repository asking for an String`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
-        configurePhilology(createRepository(nameId, repoCharSequence))
+        configurePhilology(createRepository(nameId, null, repoCharSequence))
         resources.getString(id) `should equal` repoString
+    }
+
+    @Test(expected = Resources.NotFoundException::class)
+    fun `Should throw an exception if the given id doesn't exist asking for a quantity text`() {
+        configureResourceGetIdException(baseResources, id)
+        resources.getQuantityText(id, quantity)
+    }
+
+    @Test
+    fun `Should return a CharSequence asking for a quantity text`() {
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        resources.getQuantityText(id, quantity) `should equal` someCharSequence
+    }
+
+    @Test(expected = Resources.NotFoundException::class)
+    fun `Should throw an exception if the given id doesn't exist asking for an quantity String`() {
+        configureResourceGetIdException(baseResources, id)
+        resources.getQuantityString(id, quantity)
+    }
+
+    @Test
+    fun `Should return a CharSequence asking for an quantity String`() {
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        resources.getQuantityString(id, quantity) `should equal` someString
+    }
+
+    @Test
+    fun `Should return a CharSequence from repository asking for a quantity text`() {
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "one", repoCharSequence))
+        resources.getQuantityText(id, quantity) `should equal` repoCharSequence
+    }
+
+    @Test
+    fun `Should return a CharSequence from repository asking for an quantity String`() {
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "one", repoCharSequence))
+        resources.getQuantityText(id, quantity) `should equal` repoString
+    }
+
+    @Test(expected = Resources.NotFoundException::class)
+    fun `Should throw an exception if id doesn't exist asking for an formatted quantity String`() {
+        configureResourceGetIdException(baseResources, id)
+        resources.getQuantityString(id, quantity, formatArg)
+    }
+
+    @Test
+    fun `Should return a CharSequence asking for an formatted quantity String`() {
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, "$someCharSequence%s")
+        resources.getQuantityString(id, quantity, formatArg) `should equal` someString + formatArg
     }
 }

--- a/philology/src/test/java/com/jcminarro/philology/ResourcesUtilTest.kt
+++ b/philology/src/test/java/com/jcminarro/philology/ResourcesUtilTest.kt
@@ -9,18 +9,19 @@ import org.amshove.kluent.calling
 import org.amshove.kluent.mock
 import org.junit.Before
 import org.junit.Test
+import java.util.Locale
 
 class ResourcesUtilTest {
 
+    private var configuration: Configuration = createConfiguration()
+    private var quantity = 1
     private val baseResources: Resources = mock()
-    private val configuration: Configuration = createConfiguration()
     private val resources = ResourcesUtil(baseResources)
     private val someCharSequence: CharSequence = "text"
     private val someString: String = someCharSequence.toString()
     private val repoCharSequence: CharSequence = "repo"
     private val repoString: String = repoCharSequence.toString()
     private val id = 0
-    private val quantity = 1
     private val formatArg = "argument"
     private val nameId = "nameId"
 
@@ -92,20 +93,6 @@ class ResourcesUtilTest {
         resources.getQuantityString(id, quantity) `should equal` someString
     }
 
-    @Test
-    fun `Should return a CharSequence from repository asking for a quantity text`() {
-        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
-        configurePhilology(createRepository(nameId, "one", repoCharSequence))
-        resources.getQuantityText(id, quantity) `should equal` repoCharSequence
-    }
-
-    @Test
-    fun `Should return a CharSequence from repository asking for an quantity String`() {
-        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
-        configurePhilology(createRepository(nameId, "one", repoCharSequence))
-        resources.getQuantityText(id, quantity) `should equal` repoString
-    }
-
     @Test(expected = Resources.NotFoundException::class)
     fun `Should throw an exception if id doesn't exist asking for an formatted quantity String`() {
         configureResourceGetIdException(baseResources, id)
@@ -116,5 +103,125 @@ class ResourcesUtilTest {
     fun `Should return a CharSequence asking for an formatted quantity String`() {
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, "$someCharSequence%s")
         resources.getQuantityString(id, quantity, formatArg) `should equal` someString + formatArg
+    }
+
+    @Test
+    fun `Should return a CharSequence for zero keyword asking for a quantity text`() {
+        quantity = 0
+        val locale = Locale("ar", "ME")
+        configuration = createConfiguration(locale)
+        setup()
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "zero", repoCharSequence), locale)
+        resources.getQuantityText(id, quantity) `should equal` repoCharSequence
+    }
+
+    @Test
+    fun `Should return a CharSequence for zero keyword asking for an quantity String`() {
+        quantity = 0
+        val locale = Locale("ar", "ME")
+        configuration = createConfiguration(locale)
+        setup()
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "zero", repoCharSequence), locale)
+        resources.getQuantityText(id, quantity) `should equal` repoString
+    }
+
+    @Test
+    fun `Should return a CharSequence for one keyword asking for a quantity text`() {
+        quantity = 1
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "one", repoCharSequence))
+        resources.getQuantityText(id, quantity) `should equal` repoCharSequence
+    }
+
+    @Test
+    fun `Should return a CharSequence for one keyword asking for an quantity String`() {
+        quantity = 1
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "one", repoCharSequence))
+        resources.getQuantityText(id, quantity) `should equal` repoString
+    }
+
+    @Test
+    fun `Should return a CharSequence for two keyword asking for a quantity text`() {
+        quantity = 2
+        val locale = Locale("ar", "ME")
+        configuration = createConfiguration(locale)
+        setup()
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "two", repoCharSequence), locale)
+        resources.getQuantityText(id, quantity) `should equal` repoCharSequence
+    }
+
+    @Test
+    fun `Should return a CharSequence for two keyword asking for an quantity String`() {
+        quantity = 2
+        val locale = Locale("ar", "ME")
+        configuration = createConfiguration(locale)
+        setup()
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "two", repoCharSequence), locale)
+        resources.getQuantityText(id, quantity) `should equal` repoString
+    }
+
+    @Test
+    fun `Should return a CharSequence for few keyword asking for a quantity text`() {
+        quantity = 2
+        val locale = Locale("ru", "RU")
+        configuration = createConfiguration(locale)
+        setup()
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "few", repoCharSequence), locale)
+        resources.getQuantityText(id, quantity) `should equal` repoCharSequence
+    }
+
+    @Test
+    fun `Should return a CharSequence for few keyword asking for an quantity String`() {
+        quantity = 2
+        val locale = Locale("ru", "RU")
+        configuration = createConfiguration(locale)
+        setup()
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "few", repoCharSequence), locale)
+        resources.getQuantityText(id, quantity) `should equal` repoString
+    }
+
+    @Test
+    fun `Should return a CharSequence for many keyword asking for a quantity text`() {
+        quantity = 5
+        val locale = Locale("ru", "RU")
+        configuration = createConfiguration(locale)
+        setup()
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "many", repoCharSequence), locale)
+        resources.getQuantityText(id, quantity) `should equal` repoCharSequence
+    }
+
+    @Test
+    fun `Should return a CharSequence for many keyword asking for an quantity String`() {
+        quantity = 5
+        val locale = Locale("ru", "RU")
+        configuration = createConfiguration(locale)
+        setup()
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "many", repoCharSequence), locale)
+        resources.getQuantityText(id, quantity) `should equal` repoString
+    }
+
+    @Test
+    fun `Should return a CharSequence for other keyword asking for a quantity text`() {
+        quantity = 2
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "other", repoCharSequence))
+        resources.getQuantityText(id, quantity) `should equal` repoCharSequence
+    }
+
+    @Test
+    fun `Should return a CharSequence for other keyword asking for an quantity String`() {
+        quantity = 2
+        configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
+        configurePhilology(createRepository(nameId, "other", repoCharSequence))
+        resources.getQuantityText(id, quantity) `should equal` repoString
     }
 }

--- a/sample/src/main/java/com/jcminarro/philology/sample/App.kt
+++ b/sample/src/main/java/com/jcminarro/philology/sample/App.kt
@@ -5,6 +5,9 @@ import com.jcminarro.philology.Philology
 import com.jcminarro.philology.PhilologyInterceptor
 import com.jcminarro.philology.PhilologyRepository
 import com.jcminarro.philology.PhilologyRepositoryFactory
+import com.jcminarro.philology.Resource
+import com.jcminarro.philology.Resource.Plural
+import com.jcminarro.philology.Resource.Text
 import io.github.inflationx.viewpump.ViewPump
 import java.util.Locale
 
@@ -21,8 +24,8 @@ class App : Application() {
 }
 
 object MyPhilologyRepositoryFactory : PhilologyRepositoryFactory {
-    override fun getPhilologyRepository(locale: Locale): PhilologyRepository? = when{
-        Locale.ENGLISH.language  == locale.language -> EnglishPhilologyRepository
+    override fun getPhilologyRepository(locale: Locale): PhilologyRepository? = when {
+        Locale.ENGLISH.language == locale.language -> EnglishPhilologyRepository
         Locale("es", "ES").language == locale.language -> SpanishPhilologyRepository
 // If we don't support a language we could return null as PhilologyRepository and
 // values from the strings resources file will be used
@@ -31,17 +34,39 @@ object MyPhilologyRepositoryFactory : PhilologyRepositoryFactory {
 }
 
 object EnglishPhilologyRepository : PhilologyRepository {
-    override fun getText(key: String): CharSequence? = when (key) {
-        "label" -> "New value for the `label` key, it could be fetched from a database or an external API server"
+    private val pluralsSample = mapOf("one" to "test one", "other" to "test other")
+    private val pluralsSampleFormat = mapOf("one" to "test one %s", "other" to "test other %s")
+    private val resourceSample = mapOf(
+        "plurals_sample" to pluralsSample,
+        "plurals_sample_format" to pluralsSampleFormat
+    )
+
+    override fun getText(resource: Resource): CharSequence? = when (resource) {
+        is Text -> when (resource.key) {
+            "label" -> "New value for the `label` key, it could be fetched from a database or an external API server"
+            else -> null
+        }
+        is Plural -> resourceSample[resource.key]?.get(resource.quantityKeyword)
 // If we don't want reword an strings we could return null and the value from the string resources file will be used
         else -> null
     }
 }
 
 object SpanishPhilologyRepository : PhilologyRepository {
-    override fun getText(key: String): CharSequence? = when (key) {
-        "label" -> "Nuevo valor para la clave `label`, puede ser obtenida de una base de datos o un servidor externo"
+    private val pluralsSample = mapOf("one" to "prueba uno", "other" to "prueba otro")
+    private val pluralsSampleFormat = mapOf("one" to "prueba uno %s", "other" to "prueba otro %s")
+    private val resourceSample = mapOf(
+        "plurals_sample" to pluralsSample,
+        "plurals_sample_format" to pluralsSampleFormat
+    )
+
+    override fun getText(resource: Resource): CharSequence? = when (resource) {
+        is Text -> when (resource.key) {
+            "label" -> "Nuevo valor para la clave `label`, puede ser obtenida de una base de datos o un servidor externo"
+            else -> null
+        }
+        is Plural -> resourceSample[resource.key]?.get(resource.quantityKeyword)
+// If we don't want reword an strings we could return null and the value from the string resources file will be used
         else -> null
     }
-
 }

--- a/sample/src/main/java/com/jcminarro/philology/sample/MainActivity.kt
+++ b/sample/src/main/java/com/jcminarro/philology/sample/MainActivity.kt
@@ -3,6 +3,7 @@ package com.jcminarro.philology.sample
 import android.content.Context
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.widget.TextView
 import com.jcminarro.philology.Philology
 import com.jcminarro.sample.R
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
@@ -16,5 +17,9 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        findViewById<TextView>(R.id.plural_label).text =
+            resources.getQuantityString(R.plurals.plurals_sample, 1)
+        findViewById<TextView>(R.id.plural_format_label).text =
+            resources.getQuantityString(R.plurals.plurals_sample_format, 1, "or another")
     }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -10,10 +10,37 @@
     >
 
     <TextView
+        android:id="@+id/default_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center|center_vertical"
+        android:text="@string/label"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        />
+
+    <TextView
+        android:id="@+id/plural_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center|center_vertical"
         android:textSize="20sp"
-        android:text="@string/label"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/default_label"
         />
+
+    <TextView
+        android:id="@+id/plural_format_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center|center_vertical"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/plural_label"
+        />
+
 </android.support.constraint.ConstraintLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,4 +1,12 @@
 <resources>
     <string name="app_name">Philology Sample</string>
-    <string name="label">It is the default value that we have into our strings resoureces file</string>
+    <string name="label">It is the default value that we have into our strings resource file</string>
+    <plurals name="plurals_sample">
+        <item quantity="one">One test</item>
+        <item quantity="other">Other test</item>
+    </plurals>
+    <plurals name="plurals_sample_format">
+        <item quantity="one">One test %s</item>
+        <item quantity="other">Other test %s</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
Added Android Quantity strings (plurals) support by modifying  `PhilologyRepository` interface:
```kotlin
interface PhilologyRepository {
    fun getText(resource: Resource): CharSequence?
}
```
The `Resource` is a sealed class which beside the regular text `key` also supports plurals so it will check the translations by `key` and `quantityKeyword` which can be one of the `["zero" | "one" | "two" | "few" | "many" | "other"]`:
```kotlin
sealed class Resource(open val key: String) {
    data class Text(override val key: String) : Resource(key)
    data class Plural(override val key: String, val quantityKeyword: String) : Resource(key)
}
```
Since the [PluralRules](https://developer.android.com/reference/android/icu/text/PluralRules) API is available only from Android 7.0 (API level 24) - added a dependency to [com.ibm.icu:icu4j](https://github.com/unicode-org/icu) library. More about pre-nougat recommandation: [developer.android.com](https://developer.android.com/guide/topics/resources/internationalization#prenougat).

Overrided resources methods so they will check repository for plurals with fallback to default value:

- `getQuantityText(id: Int, quantity: Int)`, 
- `getQuantityString(id: Int, quantity: Int)`
- `getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?)` 

Check the sample app for more info regarding implementation details.

