### PR TITLE
Remove icu4j dependency

### DIFF
--- a/buildSrc/src/main/groovy/com/jcminarro/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/com/jcminarro/Dependencies.groovy
@@ -13,7 +13,6 @@ class Dependencies {
     private static String KLUENT_VERSION = '1.28'
     private static String MOKITO_KOTLIN_VERSION = '1.5.0'
     private static String VIEW_PUMP_VERSION = '1.0.0'
-    private static String ICU4J_VERSION = '64.2'
 
     static final String kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
     static final String androidBuildToolGradlePlugin = "com.android.tools.build:gradle:$ANDROID_BUILD_TOOL_VERSION"
@@ -28,5 +27,4 @@ class Dependencies {
     static final String kluent = "org.amshove.kluent:kluent:$KLUENT_VERSION"
     static final String mockitoKotlin = "com.nhaarman:mockito-kotlin:$MOKITO_KOTLIN_VERSION"
     static final String viewPump = "io.github.inflationx:viewpump:$VIEW_PUMP_VERSION"
-    static final String icu4j = "com.ibm.icu:icu4j:$ICU4J_VERSION"
 }

--- a/philology/build.gradle
+++ b/philology/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     implementation Dependencies.kotlinSTDLib
     implementation Dependencies.appCompat
     implementation Dependencies.viewPump
-    implementation Dependencies.icu4j
 
     testImplementation Dependencies.robolectric
     testImplementation Dependencies.jUnit

--- a/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
+++ b/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
@@ -1,8 +1,8 @@
 package com.jcminarro.philology
 
 import android.content.res.Resources
+import android.icu.text.PluralRules
 import android.os.Build
-import com.ibm.icu.text.PluralRules
 import java.util.Locale
 
 internal class ResourcesUtil(private val baseResources: Resources) {
@@ -23,7 +23,7 @@ internal class ResourcesUtil(private val baseResources: Resources) {
     fun getQuantityText(id: Int, quantity: Int): CharSequence = repository.getText(
         Resource.Plural(
             baseResources.getResourceEntryName(id),
-            quantity.toPluralKeyword(baseResources.currentLocale())
+            quantity.toPluralKeyword(baseResources)
         )
     ) ?: baseResources.getQuantityText(id, quantity)
 
@@ -52,6 +52,8 @@ private fun Resources.currentLocale(): Locale = if (Build.VERSION.SDK_INT <= Bui
     configuration.locales[0]
 }
 
-private fun Int.toPluralKeyword(locale: Locale): String {
-    return PluralRules.forLocale(locale).select(this.toDouble())
+private fun Int.toPluralKeyword(baseResources: Resources): String = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+    PluralRules.forLocale(baseResources.currentLocale()).select(this.toDouble())
+} else {
+    baseResources.getQuantityString(R.plurals.com_jcminarro_philology_quantity_string, this)
 }

--- a/philology/src/main/res/values/strings.xml
+++ b/philology/src/main/res/values/strings.xml
@@ -1,0 +1,10 @@
+<resources>
+    <plurals name="com_jcminarro_philology_quantity_string" translatable="false">
+        <item quantity="one">one</item>
+        <item quantity="other">other</item>
+        <item quantity="few">few</item>
+        <item quantity="many">many</item>
+        <item quantity="two">two</item>
+        <item quantity="zero">zero</item>
+    </plurals>
+</resources>

--- a/philology/src/main/res/values/strings.xml
+++ b/philology/src/main/res/values/strings.xml
@@ -1,11 +1,11 @@
 <resources>
     <plurals name="com_jcminarro_philology_quantity_string" translatable="false">
+        <item quantity="zero">zero</item>
         <item quantity="one">one</item>
-        <item quantity="other">other</item>
+        <item quantity="two">two</item>
         <item quantity="few">few</item>
         <item quantity="many">many</item>
-        <item quantity="two">two</item>
-        <item quantity="zero">zero</item>
+        <item quantity="other">other</item>
     </plurals>
     <public/>
 </resources>

--- a/philology/src/main/res/values/strings.xml
+++ b/philology/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
         <item quantity="two">two</item>
         <item quantity="zero">zero</item>
     </plurals>
+    <public/>
 </resources>

--- a/philology/src/test/java/com/jcminarro/philology/Mother.kt
+++ b/philology/src/test/java/com/jcminarro/philology/Mother.kt
@@ -4,7 +4,6 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.LocaleList
 import android.util.AttributeSet
-import com.ibm.icu.impl.number.DecimalQuantity
 import com.jcminarro.philology.Resource.Plural
 import com.jcminarro.philology.Resource.Text
 import com.nhaarman.mockito_kotlin.doAnswer

--- a/philology/src/test/java/com/jcminarro/philology/Mother.kt
+++ b/philology/src/test/java/com/jcminarro/philology/Mother.kt
@@ -32,6 +32,13 @@ fun configureResourceGetText(
     When calling resources.getText(id) doReturn text
 }
 
+fun configureResourceQuantityString(resources: Resources, quantity: Int, quantityString: String) {
+    When calling resources.getQuantityString(
+        R.plurals.com_jcminarro_philology_quantity_string,
+        quantity
+    ) doReturn quantityString
+}
+
 fun configureResourceGetIdException(resources: Resources, id: Int) {
     When calling resources.getResourceEntryName(id) doThrow Resources.NotFoundException()
 }

--- a/philology/src/test/java/com/jcminarro/philology/ResourcesUtilTest.kt
+++ b/philology/src/test/java/com/jcminarro/philology/ResourcesUtilTest.kt
@@ -77,6 +77,7 @@ class ResourcesUtilTest {
 
     @Test
     fun `Should return a CharSequence asking for a quantity text`() {
+        configureResourceQuantityString(baseResources, quantity, "one")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         resources.getQuantityText(id, quantity) `should equal` someCharSequence
     }
@@ -89,6 +90,7 @@ class ResourcesUtilTest {
 
     @Test
     fun `Should return a CharSequence asking for an quantity String`() {
+        configureResourceQuantityString(baseResources, quantity, "one")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         resources.getQuantityString(id, quantity) `should equal` someString
     }
@@ -101,6 +103,7 @@ class ResourcesUtilTest {
 
     @Test
     fun `Should return a CharSequence asking for an formatted quantity String`() {
+        configureResourceQuantityString(baseResources, quantity, "one")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, "$someCharSequence%s")
         resources.getQuantityString(id, quantity, formatArg) `should equal` someString + formatArg
     }
@@ -111,6 +114,7 @@ class ResourcesUtilTest {
         val locale = Locale("ar", "ME")
         configuration = createConfiguration(locale)
         setup()
+        configureResourceQuantityString(baseResources, quantity, "zero")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "zero", repoCharSequence), locale)
         resources.getQuantityText(id, quantity) `should equal` repoCharSequence
@@ -122,6 +126,7 @@ class ResourcesUtilTest {
         val locale = Locale("ar", "ME")
         configuration = createConfiguration(locale)
         setup()
+        configureResourceQuantityString(baseResources, quantity, "zero")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "zero", repoCharSequence), locale)
         resources.getQuantityText(id, quantity) `should equal` repoString
@@ -130,6 +135,7 @@ class ResourcesUtilTest {
     @Test
     fun `Should return a CharSequence for one keyword asking for a quantity text`() {
         quantity = 1
+        configureResourceQuantityString(baseResources, quantity, "one")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "one", repoCharSequence))
         resources.getQuantityText(id, quantity) `should equal` repoCharSequence
@@ -138,6 +144,7 @@ class ResourcesUtilTest {
     @Test
     fun `Should return a CharSequence for one keyword asking for an quantity String`() {
         quantity = 1
+        configureResourceQuantityString(baseResources, quantity, "one")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "one", repoCharSequence))
         resources.getQuantityText(id, quantity) `should equal` repoString
@@ -149,6 +156,7 @@ class ResourcesUtilTest {
         val locale = Locale("ar", "ME")
         configuration = createConfiguration(locale)
         setup()
+        configureResourceQuantityString(baseResources, quantity, "two")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "two", repoCharSequence), locale)
         resources.getQuantityText(id, quantity) `should equal` repoCharSequence
@@ -160,6 +168,7 @@ class ResourcesUtilTest {
         val locale = Locale("ar", "ME")
         configuration = createConfiguration(locale)
         setup()
+        configureResourceQuantityString(baseResources, quantity, "two")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "two", repoCharSequence), locale)
         resources.getQuantityText(id, quantity) `should equal` repoString
@@ -171,6 +180,7 @@ class ResourcesUtilTest {
         val locale = Locale("ru", "RU")
         configuration = createConfiguration(locale)
         setup()
+        configureResourceQuantityString(baseResources, quantity, "few")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "few", repoCharSequence), locale)
         resources.getQuantityText(id, quantity) `should equal` repoCharSequence
@@ -182,6 +192,7 @@ class ResourcesUtilTest {
         val locale = Locale("ru", "RU")
         configuration = createConfiguration(locale)
         setup()
+        configureResourceQuantityString(baseResources, quantity, "few")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "few", repoCharSequence), locale)
         resources.getQuantityText(id, quantity) `should equal` repoString
@@ -193,6 +204,7 @@ class ResourcesUtilTest {
         val locale = Locale("ru", "RU")
         configuration = createConfiguration(locale)
         setup()
+        configureResourceQuantityString(baseResources, quantity, "many")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "many", repoCharSequence), locale)
         resources.getQuantityText(id, quantity) `should equal` repoCharSequence
@@ -204,6 +216,7 @@ class ResourcesUtilTest {
         val locale = Locale("ru", "RU")
         configuration = createConfiguration(locale)
         setup()
+        configureResourceQuantityString(baseResources, quantity, "many")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "many", repoCharSequence), locale)
         resources.getQuantityText(id, quantity) `should equal` repoString
@@ -212,6 +225,7 @@ class ResourcesUtilTest {
     @Test
     fun `Should return a CharSequence for other keyword asking for a quantity text`() {
         quantity = 2
+        configureResourceQuantityString(baseResources, quantity, "other")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "other", repoCharSequence))
         resources.getQuantityText(id, quantity) `should equal` repoCharSequence
@@ -220,6 +234,7 @@ class ResourcesUtilTest {
     @Test
     fun `Should return a CharSequence for other keyword asking for an quantity String`() {
         quantity = 2
+        configureResourceQuantityString(baseResources, quantity, "other")
         configureResourceGetQuantityText(baseResources, id, nameId, quantity, someCharSequence)
         configurePhilology(createRepository(nameId, "other", repoCharSequence))
         resources.getQuantityText(id, quantity) `should equal` repoString

--- a/sample/src/main/java/com/jcminarro/philology/sample/App.kt
+++ b/sample/src/main/java/com/jcminarro/philology/sample/App.kt
@@ -24,9 +24,10 @@ class App : Application() {
 }
 
 object MyPhilologyRepositoryFactory : PhilologyRepositoryFactory {
-    override fun getPhilologyRepository(locale: Locale): PhilologyRepository? = when {
-        Locale.ENGLISH.language == locale.language -> EnglishPhilologyRepository
-        Locale("es", "ES").language == locale.language -> SpanishPhilologyRepository
+    override fun getPhilologyRepository(locale: Locale): PhilologyRepository? = when (locale) {
+        Locale.ENGLISH -> EnglishPhilologyRepository
+        Locale("es", "ES") -> SpanishPhilologyRepository
+        Locale("ru", "RU") -> RussianPhilologyRepository
 // If we don't support a language we could return null as PhilologyRepository and
 // values from the strings resources file will be used
         else -> null
@@ -35,7 +36,7 @@ object MyPhilologyRepositoryFactory : PhilologyRepositoryFactory {
 
 object EnglishPhilologyRepository : PhilologyRepository {
     private val pluralsSample = mapOf("one" to "test one", "other" to "test other")
-    private val pluralsSampleFormat = mapOf("one" to "test one %s", "other" to "test other %s")
+    private val pluralsSampleFormat = mapOf("one" to "%s test one", "other" to "%s tests")
     private val resourceSample = mapOf(
         "plurals_sample" to pluralsSample,
         "plurals_sample_format" to pluralsSampleFormat
@@ -66,7 +67,34 @@ object SpanishPhilologyRepository : PhilologyRepository {
             else -> null
         }
         is Plural -> resourceSample[resource.key]?.get(resource.quantityKeyword)
-// If we don't want reword an strings we could return null and the value from the string resources file will be used
+        else -> null
+    }
+}
+
+object RussianPhilologyRepository : PhilologyRepository {
+    private val pluralsSample = mapOf(
+        "one" to "один тест",
+        "other" to "другие тесты",
+        "few" to "несколько теста",
+        "many" to "много тестов"
+    )
+    private val pluralsSampleFormat = mapOf(
+        "one" to "%s тест",
+        "other" to "%s тесты",
+        "few" to "%s теста",
+        "many" to "%s тестов"
+    )
+    private val resourceSample = mapOf(
+        "plurals_sample" to pluralsSample,
+        "plurals_sample_format" to pluralsSampleFormat
+    )
+
+    override fun getText(resource: Resource): CharSequence? = when (resource) {
+        is Text -> when (resource.key) {
+            "label" -> "Новое значение для ключа `label`, его можно получить из базы данных или внешнего сервера API"
+            else -> null
+        }
+        is Plural -> resourceSample[resource.key]?.get(resource.quantityKeyword)
         else -> null
     }
 }

--- a/sample/src/main/java/com/jcminarro/philology/sample/App.kt
+++ b/sample/src/main/java/com/jcminarro/philology/sample/App.kt
@@ -75,7 +75,7 @@ object RussianPhilologyRepository : PhilologyRepository {
     private val pluralsSample = mapOf(
         "one" to "один тест",
         "other" to "другие тесты",
-        "few" to "несколько теста",
+        "few" to "несколько тестов",
         "many" to "много тестов"
     )
     private val pluralsSampleFormat = mapOf(

--- a/sample/src/main/java/com/jcminarro/philology/sample/MainActivity.kt
+++ b/sample/src/main/java/com/jcminarro/philology/sample/MainActivity.kt
@@ -3,6 +3,9 @@ package com.jcminarro.philology.sample
 import android.content.Context
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.text.Editable
+import android.text.TextWatcher
+import android.widget.EditText
 import android.widget.TextView
 import com.jcminarro.philology.Philology
 import com.jcminarro.sample.R
@@ -17,9 +20,32 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        findViewById<TextView>(R.id.plural_label).text =
-            resources.getQuantityString(R.plurals.plurals_sample, 1)
-        findViewById<TextView>(R.id.plural_format_label).text =
-            resources.getQuantityString(R.plurals.plurals_sample_format, 1, "or another")
+        val pluralLabel = findViewById<TextView>(R.id.plural_label)
+        findViewById<EditText>(R.id.plural_quantity_edit).afterTextChanged { text: String ->
+            text.toIntOrNull()?.let {
+                pluralLabel.text = resources.getQuantityString(R.plurals.plurals_sample, it)
+            }
+        }
+
+        val pluralFormatLabel = findViewById<TextView>(R.id.plural_format_label)
+        findViewById<EditText>(R.id.plural_quantity_format_edit).afterTextChanged { text: String ->
+            text.toIntOrNull()?.let {
+                pluralFormatLabel.text = resources.getQuantityString(R.plurals.plurals_sample_format, it, it)
+            }
+        }
+    }
+
+    private fun EditText.afterTextChanged(afterTextChanged: (String) -> Unit) {
+        this.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+
+            override fun afterTextChanged(editable: Editable?) {
+                afterTextChanged.invoke(editable.toString())
+            }
+        })
     }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -21,6 +21,18 @@
         app:layout_constraintTop_toTopOf="parent"
         />
 
+    <EditText
+        android:id="@+id/plural_quantity_edit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="Plural quantity edit"
+        android:inputType="numberDecimal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/default_label"
+        />
+
     <TextView
         android:id="@+id/plural_label"
         android:layout_width="wrap_content"
@@ -29,7 +41,19 @@
         android:textSize="20sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/default_label"
+        app:layout_constraintTop_toBottomOf="@id/plural_quantity_edit"
+        />
+
+    <EditText
+        android:id="@+id/plural_quantity_format_edit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="Plural quantity format edit"
+        android:inputType="numberDecimal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/plural_label"
         />
 
     <TextView
@@ -40,7 +64,7 @@
         android:textSize="20sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/plural_label"
+        app:layout_constraintTop_toBottomOf="@id/plural_quantity_format_edit"
         />
 
 </android.support.constraint.ConstraintLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -3,10 +3,10 @@
     <string name="label">It is the default value that we have into our strings resource file</string>
     <plurals name="plurals_sample">
         <item quantity="one">One test</item>
-        <item quantity="other">Other test</item>
+        <item quantity="other">Other tests</item>
     </plurals>
     <plurals name="plurals_sample_format">
-        <item quantity="one">One test %s</item>
-        <item quantity="other">Other test %s</item>
+        <item quantity="one">%d test</item>
+        <item quantity="other">%d tests</item>
     </plurals>
 </resources>


### PR DESCRIPTION
By adding Android Quantity strings (plurals) support in #9 PR the library increased by ~12.2 MB in size because of the [com.ibm.icu:icu4j](https://github.com/unicode-org/icu) added library. That was necessary since as stated there the [PluralRules](https://developer.android.com/reference/android/icu/text/PluralRules) API is available only from Android 7.0 (API level 24).

This PR proposes a workaround for prenougat devices (< API level 24) by indirect
use of `PluralRules` trough declared `com_jcminarro_philology_quantity_string` [private](https://developer.android.com/studio/projects/android-library#PrivateResources) plurals resource in `strings.xml`, where each quantity string key = value:

```xml

    <plurals name="com_jcminarro_philology_quantity_string" translatable="false">
        <item quantity="zero">zero</item>
        <item quantity="one">one</item>
        <item quantity="two">two</item>
        <item quantity="few">few</item>
        <item quantity="many">many</item>
        <item quantity="other">other</item>
    </plurals>

```
In this way, the keys will give you the right value for the current locale, for example, it will take "many" key/value for Russian locale for numbers above 5. 
More about plural rules: [language_plural_rules](https://unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html).
For API 24 and above it will use `PluralRules`class from `android.icu` package in the android framework.

Also updated the sample by adding `RussianPhilologyRepository` and editable quantity fields to facilitate plurals testing:
<img src="https://user-images.githubusercontent.com/1947850/62381579-79642f80-b554-11e9-9ee8-e33b4f9c5ea1.png" width =300 />
