### PR TITLE
Add string array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,30 @@ object MyPhilologyRepositoryFactory : PhilologyRepositoryFactory {
 }
 
 object EnglishPhilologyRepository : PhilologyRepository {
-    override fun getText(resource: Resource): CharSequence? = when (resource) {
-        is Text -> when (resource.key) {
-            "label" -> "New value for the `label` key, it could be fetched from a database or an external API server"
-            else -> null
-        }
-        is Plural -> when ("${resource.key}_${resource.quantityKeyword}") {
-            "plurals_label_one" -> "New value for the `plurals_label` key and `one` quantity keyword"
-            "plurals_label_other" -> "New value for the `plurals_label` key and `other` quantity keyword"
-            else -> null
-        }
-// If we don't want reword an strings we could return null and the value from the string resources file will be used
+    override fun getText(key: String): CharSequence? = when (key) {
+        "label" -> "New value for the `label` key, it could be fetched from a database or an external API server"
+        // If we don't want reword a strings we could return null and the value from the string resources file will be used
+        else -> null
+    }
+
+    override fun getPlural(key: String, quantityString: String): CharSequence?  = when ("${key}_$quantityString") {
+        "plurals_label_one" -> "New value for the `plurals_label` key and `one` quantity keyword"
+        "plurals_label_other" -> "New value for the `plurals_label` key and `other` quantity keyword"
+        // If we don't want reword a plural we could return null and the value from the string resources file will be used
+        else -> null
+    }
+
+   override fun getTextArray(key: String): Array<CharSequence>? = when (key) {
+        "days" -> arrayOf(
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Saturday"
+        )
+        // If we don't want reword a string array we could return null and the value from the string resources file will be used
         else -> null
     }
 }

--- a/philology/src/main/java/com/jcminarro/philology/Philology.kt
+++ b/philology/src/main/java/com/jcminarro/philology/Philology.kt
@@ -14,7 +14,7 @@ import java.util.Locale
 
 object Philology {
     private val repositoryMap = mutableMapOf<Locale, PhilologyRepository>()
-    private var factory: PhilologyRepositoryFactory = object : PhilologyRepositoryFactory{
+    private var factory: PhilologyRepositoryFactory = object : PhilologyRepositoryFactory {
         override fun getPhilologyRepository(locale: Locale): PhilologyRepository? = null
     }
     private var viewTransformerFactory: ViewTransformerFactory = emptyViewTransformerFactory
@@ -47,15 +47,13 @@ interface ViewTransformerFactory {
     fun getViewTransformer(view: View): ViewTransformer?
 }
 
-private val emptyPhilologyRepository = object : PhilologyRepository{
-    override fun getText(resource: Resource): CharSequence? = null
-}
+private val emptyPhilologyRepository = object : PhilologyRepository {}
 
 private val emptyViewTransformerFactory = object : ViewTransformerFactory {
     override fun getViewTransformer(view: View): ViewTransformer? = null
 }
 
-private val internalViewTransformerFactory = object : ViewTransformerFactory{
+private val internalViewTransformerFactory = object : ViewTransformerFactory {
     override fun getViewTransformer(view: View): ViewTransformer =
             getNewApiViewTransformer(view) ?:
                     getSupportedViewTransformer(view) ?:

--- a/philology/src/main/java/com/jcminarro/philology/PhilologyResources.kt
+++ b/philology/src/main/java/com/jcminarro/philology/PhilologyResources.kt
@@ -3,16 +3,24 @@ package com.jcminarro.philology
 import android.content.res.Resources
 
 @Suppress("DEPRECATION")
-internal class PhilologyResources(baseResources: Resources)
-    : Resources(baseResources.assets, baseResources.displayMetrics, baseResources.configuration) {
+internal class PhilologyResources(baseResources: Resources) :
+    Resources(baseResources.assets, baseResources.displayMetrics, baseResources.configuration) {
     private val resourcesUtil = ResourcesUtil(baseResources)
 
     override fun getText(id: Int): CharSequence = resourcesUtil.getText(id)
+
     override fun getString(id: Int): String = resourcesUtil.getString(id)
+
     override fun getQuantityText(id: Int, quantity: Int): CharSequence =
         resourcesUtil.getQuantityText(id, quantity)
+
     override fun getQuantityString(id: Int, quantity: Int): String =
         resourcesUtil.getQuantityString(id, quantity)
+
     override fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String =
         resourcesUtil.getQuantityString(id, quantity, *formatArgs)
+
+    override fun getStringArray(id: Int): Array<String> = resourcesUtil.getStringArray(id)
+
+    override fun getTextArray(id: Int): Array<CharSequence> = resourcesUtil.getTextArray(id)
 }

--- a/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
+++ b/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
@@ -32,7 +32,8 @@ internal class ResourcesUtil(private val baseResources: Resources) {
     fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String =
         String.format(getQuantityString(id, quantity), *formatArgs)
 
-    fun getStringArray(id: Int) = getTextArray(id).map { it.toString() }.toTypedArray()
+    fun getStringArray(id: Int): Array<String> =
+        getTextArray(id).map { it.toString() }.toTypedArray()
 
     fun getTextArray(id: Int): Array<CharSequence> {
         return repository.getTextArray(baseResources.getResourceEntryName(id))

--- a/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
+++ b/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
@@ -29,9 +29,8 @@ internal class ResourcesUtil(private val baseResources: Resources) {
     fun getQuantityString(id: Int, quantity: Int): String = getQuantityText(id, quantity).toString()
 
     @Throws(Resources.NotFoundException::class)
-    fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String {
-        return String.format(getQuantityString(id, quantity), *formatArgs)
-    }
+    fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String =
+        String.format(getQuantityString(id, quantity), *formatArgs)
 
     fun getStringArray(id: Int) = getTextArray(id).map { it.toString() }.toTypedArray()
 

--- a/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
+++ b/philology/src/main/java/com/jcminarro/philology/ResourcesUtil.kt
@@ -12,7 +12,7 @@ internal class ResourcesUtil(private val baseResources: Resources) {
 
     @Throws(Resources.NotFoundException::class)
     fun getText(id: Int): CharSequence {
-        return repository.getText(Resource.Text(baseResources.getResourceEntryName(id)))
+        return repository.getText(baseResources.getResourceEntryName(id))
             ?: baseResources.getText(id)
     }
 
@@ -20,28 +20,31 @@ internal class ResourcesUtil(private val baseResources: Resources) {
     fun getString(id: Int): String = getText(id).toString()
 
     @Throws(Resources.NotFoundException::class)
-    fun getQuantityText(id: Int, quantity: Int): CharSequence = repository.getText(
-        Resource.Plural(
-            baseResources.getResourceEntryName(id),
-            quantity.toPluralKeyword(baseResources)
-        )
+    fun getQuantityText(id: Int, quantity: Int): CharSequence = repository.getPlural(
+        baseResources.getResourceEntryName(id),
+        quantity.toPluralKeyword(baseResources)
     ) ?: baseResources.getQuantityText(id, quantity)
 
     @Throws(Resources.NotFoundException::class)
     fun getQuantityString(id: Int, quantity: Int): String = getQuantityText(id, quantity).toString()
 
     @Throws(Resources.NotFoundException::class)
-    fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String =
-        String.format(getQuantityString(id, quantity), *formatArgs)
+    fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String {
+        return String.format(getQuantityString(id, quantity), *formatArgs)
+    }
+
+    fun getStringArray(id: Int) = getTextArray(id).map { it.toString() }.toTypedArray()
+
+    fun getTextArray(id: Int): Array<CharSequence> {
+        return repository.getTextArray(baseResources.getResourceEntryName(id))
+            ?: baseResources.getTextArray(id)
+    }
 }
 
 interface PhilologyRepository {
-    fun getText(resource: Resource): CharSequence?
-}
-
-sealed class Resource(open val key: String) {
-    data class Text(override val key: String) : Resource(key)
-    data class Plural(override val key: String, val quantityKeyword: String) : Resource(key)
+    fun getText(key: String): CharSequence? = null
+    fun getPlural(key: String, quantityString: String): CharSequence? = null
+    fun getTextArray(key: String): Array<CharSequence>? = null
 }
 
 @SuppressWarnings("NewApi")

--- a/philology/src/test/java/com/jcminarro/philology/Mother.kt
+++ b/philology/src/test/java/com/jcminarro/philology/Mother.kt
@@ -12,7 +12,6 @@ import org.amshove.kluent.When
 import org.amshove.kluent.calling
 import org.amshove.kluent.mock
 import org.mockito.Mockito
-import org.robolectric.res.Plural
 import java.util.Locale
 
 fun createConfiguration(locale: Locale = Locale.ENGLISH): Configuration = mock<Configuration>().apply {

--- a/philology/src/test/java/com/jcminarro/philology/Mother.kt
+++ b/philology/src/test/java/com/jcminarro/philology/Mother.kt
@@ -4,8 +4,6 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.LocaleList
 import android.util.AttributeSet
-import com.jcminarro.philology.Resource.Plural
-import com.jcminarro.philology.Resource.Text
 import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.doThrow
@@ -14,6 +12,7 @@ import org.amshove.kluent.When
 import org.amshove.kluent.calling
 import org.amshove.kluent.mock
 import org.mockito.Mockito
+import org.robolectric.res.Plural
 import java.util.Locale
 
 fun createConfiguration(locale: Locale = Locale.ENGLISH): Configuration = mock<Configuration>().apply {
@@ -50,20 +49,33 @@ fun configureResourceGetQuantityText(
     When calling resources.getQuantityText(id, quantity) doReturn text
 }
 
+fun configureResourceGetTextArray(
+    resources: Resources, id: Int, nameId: String, textArray: Array<CharSequence>
+) {
+    When calling resources.getResourceEntryName(id) doReturn nameId
+    When calling resources.getTextArray(id) doReturn textArray
+}
+
 fun clearPhilology() {
     Philology.init(object : PhilologyRepositoryFactory {
         override fun getPhilologyRepository(locale: Locale): PhilologyRepository? = null
     })
 }
 
-fun createRepository(nameId: String, quantity: String?, text: CharSequence): PhilologyRepository =
+fun createRepository(
+    nameId: String,
+    quantity: String? = null,
+    text: CharSequence? = null,
+    textArray: Array<CharSequence>? = null
+): PhilologyRepository =
     object : PhilologyRepository {
-        override fun getText(resource: Resource): CharSequence? = when (resource) {
-            is Text -> text.takeIf { resource.key == nameId }
-            is Plural -> text.takeIf {
-                resource.key == nameId && resource.quantityKeyword == quantity
-            }
+        override fun getText(key: String) = text.takeIf { key == nameId }
+
+        override fun getPlural(key: String, quantityString: String): CharSequence? {
+            return text.takeIf { key == nameId && quantity == quantity }
         }
+
+        override fun getTextArray(key: String) = textArray.takeIf { key == nameId }
     }
 
 fun createFactory(vararg repositoryPairs: Pair<Locale, PhilologyRepository>): PhilologyRepositoryFactory =

--- a/philology/src/test/java/com/jcminarro/philology/PhilologyResourcesTest.kt
+++ b/philology/src/test/java/com/jcminarro/philology/PhilologyResourcesTest.kt
@@ -52,6 +52,58 @@ class PhilologyResourcesTest {
         resources.getString(id) `should equal` someString
     }
 
+    @Test(expected = Resources.NotFoundException::class)
+    fun `Should throw an exception if the given id doesn't exist asking for a quantity text`() {
+        configureResourceGetIdException(baseResources, id)
+        resources.getQuantityText(id, 1)
+    }
+
+    @Test
+    fun `Should return a CharSequence asking for a quantity text`() {
+        configureResourceQuantityString(baseResources, 1, "one")
+        configureResourceGetQuantityText(baseResources, id, nameId, 1, someCharSequence)
+        resources.getQuantityText(id, 1) `should equal` someCharSequence
+    }
+
+    @Test(expected = Resources.NotFoundException::class)
+    fun `Should throw an exception if the given id doesn't exist asking for an quantity string`() {
+        configureResourceGetIdException(baseResources, id)
+        resources.getQuantityString(id, 1)
+    }
+
+    @Test
+    fun `Should return a CharSequence asking for an quantity string`() {
+        configureResourceQuantityString(baseResources, 1, "one")
+        configureResourceGetQuantityText(baseResources, id, nameId, 1, someCharSequence)
+        resources.getQuantityString(id, 1) `should equal` someString
+    }
+
+    @Test(expected = Resources.NotFoundException::class)
+    fun `Should throw an exception if the given id doesn't exist asking for a string array`() {
+        configureResourceGetIdException(baseResources, id)
+        resources.getStringArray(id)
+    }
+
+    @Test
+    fun `Should return a CharSequence asking for a string array`() {
+        val textArray = arrayOf<CharSequence>("first", "second")
+        configureResourceGetTextArray(baseResources, id, nameId, textArray)
+        resources.getStringArray(id) `should equal` textArray.map { it.toString() }.toTypedArray()
+    }
+
+    @Test(expected = Resources.NotFoundException::class)
+    fun `Should throw an exception if the given id doesn't exist asking for a text array`() {
+        configureResourceGetIdException(baseResources, id)
+        resources.getStringArray(id)
+    }
+
+    @Test
+    fun `Should return a CharSequence asking for a text array`() {
+        val textArray = arrayOf<CharSequence>("first", "second")
+        configureResourceGetTextArray(baseResources, id, nameId, textArray)
+        resources.getTextArray(id) `should equal` textArray
+    }
+
     @Test()
     fun `Should return a CharSequence from repository asking for a text`() {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
@@ -64,5 +116,37 @@ class PhilologyResourcesTest {
         configureResourceGetText(baseResources, id, nameId, someCharSequence)
         configurePhilology(createRepository(nameId, null, repoCharSequence))
         resources.getString(id) `should equal` repoString
+    }
+
+    @Test
+    fun `Should return a CharSequence from repository asking for a quantity text`() {
+        configureResourceQuantityString(baseResources, 1, "one")
+        configureResourceGetQuantityText(baseResources, id, nameId, 1, someCharSequence)
+        configurePhilology(createRepository(nameId, "one", repoCharSequence))
+        resources.getQuantityText(id, 1) `should equal` repoCharSequence
+    }
+
+    @Test
+    fun `Should return a CharSequence from repository asking for an quantity string`() {
+        configureResourceQuantityString(baseResources, 1, "one")
+        configureResourceGetQuantityText(baseResources, id, nameId, 1, someCharSequence)
+        configurePhilology(createRepository(nameId, "one", repoCharSequence))
+        resources.getQuantityString(id, 1) `should equal` repoString
+    }
+
+    @Test
+    fun `Should return a CharSequence from repository asking for a string array`() {
+        val textArray: Array<CharSequence> = arrayOf("first", "second")
+        configureResourceGetTextArray(baseResources, id, nameId, textArray)
+        configurePhilology(createRepository(nameId, textArray = textArray))
+        resources.getStringArray(id) `should equal` textArray.map { it.toString() }.toTypedArray()
+    }
+
+    @Test
+    fun `Should return a CharSequence from repository asking for a text array`() {
+        val textArray: Array<CharSequence> = arrayOf("first", "second")
+        configureResourceGetTextArray(baseResources, id, nameId, textArray)
+        configurePhilology(createRepository(nameId, textArray = textArray))
+        resources.getTextArray(id) `should equal` textArray
     }
 }

--- a/philology/src/test/java/com/jcminarro/philology/ResourcesUtilTest.kt
+++ b/philology/src/test/java/com/jcminarro/philology/ResourcesUtilTest.kt
@@ -239,4 +239,46 @@ class ResourcesUtilTest {
         configurePhilology(createRepository(nameId, "other", repoCharSequence))
         resources.getQuantityText(id, quantity) `should equal` repoString
     }
+
+    @Test(expected = Resources.NotFoundException::class)
+    fun `Should throw an exception if the given id doesn't exist asking for text array`() {
+        configureResourceGetIdException(baseResources, id)
+        resources.getTextArray(id)
+    }
+
+    @Test
+    fun `Should return an array of strings asking for a text array`() {
+        val textArray: Array<CharSequence> = arrayOf("first", "second")
+        configureResourceGetTextArray(baseResources, id, nameId, textArray)
+        resources.getTextArray(id) `should equal` textArray
+    }
+
+    @Test(expected = Resources.NotFoundException::class)
+    fun `Should throw an exception if the given id doesn't exist asking for a string array`() {
+        configureResourceGetIdException(baseResources, id)
+        resources.getStringArray(id)
+    }
+
+    @Test
+    fun `Should return an array of strings asking for a string array`() {
+        val textArray: Array<CharSequence> = arrayOf("first", "second")
+        configureResourceGetTextArray(baseResources, id, nameId, textArray)
+        resources.getStringArray(id) `should equal` textArray.map { it.toString() }.toTypedArray()
+    }
+
+    @Test
+    fun `Should return an array of strings from repository asking for a text array`() {
+        val textArray: Array<CharSequence> = arrayOf("first", "second")
+        configureResourceGetTextArray(baseResources, id, nameId, textArray)
+        configurePhilology(createRepository(nameId, textArray = textArray))
+        resources.getTextArray(id) `should equal` textArray
+    }
+
+    @Test
+    fun `Should return an array of strings from repository asking for a string array`() {
+        val textArray: Array<CharSequence> = arrayOf("first", "second")
+        configureResourceGetTextArray(baseResources, id, nameId, textArray)
+        configurePhilology(createRepository(nameId, textArray = textArray))
+        resources.getStringArray(id) `should equal` textArray.map { it.toString() }.toTypedArray()
+    }
 }

--- a/sample/src/main/java/com/jcminarro/philology/sample/App.kt
+++ b/sample/src/main/java/com/jcminarro/philology/sample/App.kt
@@ -5,9 +5,6 @@ import com.jcminarro.philology.Philology
 import com.jcminarro.philology.PhilologyInterceptor
 import com.jcminarro.philology.PhilologyRepository
 import com.jcminarro.philology.PhilologyRepositoryFactory
-import com.jcminarro.philology.Resource
-import com.jcminarro.philology.Resource.Plural
-import com.jcminarro.philology.Resource.Text
 import io.github.inflationx.viewpump.ViewPump
 import java.util.Locale
 
@@ -42,14 +39,13 @@ object EnglishPhilologyRepository : PhilologyRepository {
         "plurals_sample_format" to pluralsSampleFormat
     )
 
-    override fun getText(resource: Resource): CharSequence? = when (resource) {
-        is Text -> when (resource.key) {
-            "label" -> "New value for the `label` key, it could be fetched from a database or an external API server"
-            else -> null
-        }
-        is Plural -> resourceSample[resource.key]?.get(resource.quantityKeyword)
-// If we don't want reword an strings we could return null and the value from the string resources file will be used
+    override fun getText(key: String): CharSequence? = when (key) {
+        "label" -> "New value for the `label` key, it could be fetched from a database or an external API server"
         else -> null
+    }
+
+    override fun getPlural(key: String, quantityString: String): CharSequence? {
+        return resourceSample[key]?.get(quantityString)
     }
 }
 
@@ -61,12 +57,25 @@ object SpanishPhilologyRepository : PhilologyRepository {
         "plurals_sample_format" to pluralsSampleFormat
     )
 
-    override fun getText(resource: Resource): CharSequence? = when (resource) {
-        is Text -> when (resource.key) {
-            "label" -> "Nuevo valor para la clave `label`, puede ser obtenida de una base de datos o un servidor externo"
-            else -> null
-        }
-        is Plural -> resourceSample[resource.key]?.get(resource.quantityKeyword)
+    override fun getText(key: String): CharSequence? = when (key) {
+        "label" -> "Nuevo valor para la clave `label`, puede ser obtenida de una base de datos o un servidor externo"
+        else -> null
+    }
+
+    override fun getPlural(key: String, quantityString: String): CharSequence? {
+        return resourceSample[key]?.get(quantityString)
+    }
+
+    override fun getTextArray(key: String) = when (key) {
+        "days" -> arrayOf<CharSequence>(
+            "lunes",
+            "martes",
+            "miércoles",
+            "jueves",
+            "viernes",
+            "sábado",
+            "domingo"
+        )
         else -> null
     }
 }
@@ -89,12 +98,25 @@ object RussianPhilologyRepository : PhilologyRepository {
         "plurals_sample_format" to pluralsSampleFormat
     )
 
-    override fun getText(resource: Resource): CharSequence? = when (resource) {
-        is Text -> when (resource.key) {
-            "label" -> "Новое значение для ключа `label`, его можно получить из базы данных или внешнего сервера API"
-            else -> null
-        }
-        is Plural -> resourceSample[resource.key]?.get(resource.quantityKeyword)
+    override fun getText(key: String): CharSequence? = when (key) {
+        "label" -> "Новое значение для ключа `label`, его можно получить из базы данных или внешнего сервера API"
+        else -> null
+    }
+
+    override fun getPlural(key: String, quantityString: String): CharSequence? {
+        return resourceSample[key]?.get(quantityString)
+    }
+
+    override fun getTextArray(key: String) = when (key) {
+        "days" -> arrayOf<CharSequence>(
+            "понедельник",
+            "вторник",
+            "среда",
+            "четверг",
+            "пятница",
+            "суббота",
+            "воскресенье"
+        )
         else -> null
     }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -67,4 +67,20 @@
         app:layout_constraintTop_toBottomOf="@id/plural_quantity_format_edit"
         />
 
+    <Spinner
+        android:id="@+id/days_spinner"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="24dp"
+        android:layout_marginLeft="24dp"
+        android:layout_marginRight="24dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="8dp"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/plural_format_label"
+        android:entries="@array/days"
+        />
+
 </android.support.constraint.ConstraintLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -9,4 +9,13 @@
         <item quantity="one">%d test</item>
         <item quantity="other">%d tests</item>
     </plurals>
+    <string-array name="days">
+        <item>Monday</item>
+        <item>Tuesday</item>
+        <item>Wednesday</item>
+        <item>Thursday</item>
+        <item>Friday</item>
+        <item>Saturday</item>
+        <item>Saturday</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
### What has been done
Added string array support. 
As the `PhilologyRepository#getText` returning type is `CharSequence` and for string array, we need `Array<String>` the simplest way was to remove Resource object and add 2 more methods to the `PhilologyRepository` for plurals and string arrays.

Now the interface looks like this: 
```Kotlin
interface PhilologyRepository {
    fun getText(key: String): CharSequence? = null
    fun getPlural(key: String, quantityString: String): CharSequence? = null
    fun getTextArray(key: String): Array<CharSequence>? = null
}
```

### Screenshots
<img src="https://user-images.githubusercontent.com/37998373/63090430-e5d32b80-bf63-11e9-983e-9195fa627420.png" width="200" align="left"/>
<img src="https://user-images.githubusercontent.com/37998373/63090411-d81da600-bf63-11e9-9eb8-6307aaaf4c9a.png" width="200" />

### How to test
1. Run the sample app and make sure simple and plurals translation is not broken.
Make 
2. Run the sample app and make sure newly added string-arrays support works properly.