### PR TITLE
Add support for AppCompat ver. 1.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/code
   docker:
-    - image: circleci/android:api-28
+    - image: circleci/android@sha256:53cb55418cf1785ef3e503868b8f8d1748034cdf0cac31fb52d44600bdd91a1f
   environment:
     TZ: Europe/Madrid
     JVM_OPTS: -Xmx3200m

--- a/README.md
+++ b/README.md
@@ -129,18 +129,19 @@ Wrap the `Activity` Context.
 Kotlin:
 ```kotlin
 class BaseActivity : AppCompatActivity() {
-    override fun attachBaseContext(newBase: Context) {
-        super.attachBaseContext(ViewPumpContextWrapper.wrap(Philology.wrap(newBase)))
-    }
+    private val delegateHolder = PhilologyAppCompatDelegateHolder()
+    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate())
 }
 ```
 
 Java:
 ```java
 public class BaseActivity extends AppCompatActivity {
+    private PhilologyAppCompatDelegateHolder delegateHolder = new PhilologyAppCompatDelegateHolder();
+    @NonNull
     @Override
-    protected void attachBaseContext(Context newBase) {
-        super.attachBaseContext(ViewPumpContextWrapper.wrap(Philology.INSTANCE.wrap(newBase)));
+    public AppCompatDelegate getDelegate() {
+        return delegateHolder.getDelegate(super.getDelegate());
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -130,18 +130,26 @@ Kotlin:
 ```kotlin
 class BaseActivity : AppCompatActivity() {
     private val delegateHolder = PhilologyAppCompatDelegateHolder()
-    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate())
+    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate()) {
+        ViewPumpContextWrapper.wrap(Philology.wrap(it))
+    }
 }
 ```
 
 Java:
 ```java
 public class BaseActivity extends AppCompatActivity {
-    private PhilologyAppCompatDelegateHolder delegateHolder = new PhilologyAppCompatDelegateHolder();
+    private final PhilologyAppCompatDelegateHolder delegateHolder = new PhilologyAppCompatDelegateHolder();
+
     @NonNull
     @Override
     public AppCompatDelegate getDelegate() {
-        return delegateHolder.getDelegate(super.getDelegate());
+        return delegateHolder.getDelegate(super.getDelegate(), new Function1<Context, Context>() {
+                    @Override
+                    public Context invoke(Context context) {
+                        return ViewPumpContextWrapper.wrap(Philology.INSTANCE.wrap(context));
+                    }
+                });
     }
 }
 ```

--- a/buildSrc/src/main/groovy/com/jcminarro/Dependencies.groovy
+++ b/buildSrc/src/main/groovy/com/jcminarro/Dependencies.groovy
@@ -4,7 +4,7 @@ class Dependencies {
 
     private static String KOTLIN_VERSION = '1.3.61'
     private static String ANDROID_BUILD_TOOL_VERSION = '3.1.3'
-    private static String APP_COMPAT_VERSION = '1.0.0'
+    private static String APP_COMPAT_VERSION = '1.2.0'
     private static String ROBOLECTRIC_VERSION = '3.8'
     private static String JUNIT_VERSION = '4.12'
     private static String ANDROID_TEST_RUNNER_VERSION = '1.0.2'

--- a/philology/src/main/java/androidx/appcompat/app/BaseContextWrappingDelegate.kt
+++ b/philology/src/main/java/androidx/appcompat/app/BaseContextWrappingDelegate.kt
@@ -1,0 +1,122 @@
+package androidx.appcompat.app
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Bundle
+import android.util.AttributeSet
+import android.view.MenuInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.RequiresApi
+import androidx.appcompat.view.ActionMode
+import androidx.appcompat.widget.Toolbar
+
+/**
+ * Solution for supporting AppCompat 1.2.0.
+ * Note: class must be inside the androidx.appcompat.app package because the only existing AppCompatDelegate constructor is package private
+ *
+ * @param superDelegate original AppCompatDelegate obtained by calling `super.getDelegate()`
+ * from `AppCompatActivity`
+ * @param onAttachBaseContext called by the AppCompat library. Make sure the context is wrapped in
+ * this lambda.
+ *
+ * @see <a href="https://stackoverflow.com/questions/55265834/change-locale-not-work-after-migrate-to-androidx">stackoverflow</a>
+ * @see androidx.appcompat.app.AppCompatActivity.getDelegate
+ */
+internal class BaseContextWrappingDelegate(
+    private val superDelegate: AppCompatDelegate,
+    private val onAttachBaseContext: (Context) -> Context
+) : AppCompatDelegate() {
+
+    override fun getSupportActionBar() = superDelegate.supportActionBar
+
+    override fun setSupportActionBar(toolbar: Toolbar?) = superDelegate.setSupportActionBar(toolbar)
+
+    override fun getMenuInflater(): MenuInflater? = superDelegate.menuInflater
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        superDelegate.onCreate(savedInstanceState)
+        removeActivityDelegate(superDelegate)
+        addActiveDelegate(this)
+    }
+
+    override fun onPostCreate(savedInstanceState: Bundle?) = superDelegate.onPostCreate(
+        savedInstanceState
+    )
+
+    override fun onConfigurationChanged(
+        newConfig: Configuration?
+    ) = superDelegate.onConfigurationChanged(newConfig)
+
+    override fun onStart() = superDelegate.onStart()
+
+    override fun onStop() = superDelegate.onStop()
+
+    override fun onPostResume() = superDelegate.onPostResume()
+
+    override fun setTheme(themeResId: Int) = superDelegate.setTheme(themeResId)
+
+    override fun <T : View?> findViewById(id: Int) = superDelegate.findViewById<T>(id)
+
+    override fun setContentView(v: View?) = superDelegate.setContentView(v)
+
+    override fun setContentView(resId: Int) = superDelegate.setContentView(resId)
+
+    override fun setContentView(
+        v: View?, lp: ViewGroup.LayoutParams?
+    ) = superDelegate.setContentView(v, lp)
+
+    override fun addContentView(
+        v: View?, lp: ViewGroup.LayoutParams?
+    ) = superDelegate.addContentView(v, lp)
+
+    override fun attachBaseContext2(context: Context) = onAttachBaseContext(
+        superDelegate.attachBaseContext2(super.attachBaseContext2(context))
+    )
+
+    override fun setTitle(title: CharSequence?) = superDelegate.setTitle(title)
+
+    override fun invalidateOptionsMenu() = superDelegate.invalidateOptionsMenu()
+
+    override fun onDestroy() {
+        superDelegate.onDestroy()
+        removeActivityDelegate(this)
+    }
+
+    override fun getDrawerToggleDelegate() = superDelegate.drawerToggleDelegate
+
+    override fun requestWindowFeature(featureId: Int) = superDelegate.requestWindowFeature(
+        featureId
+    )
+
+    override fun hasWindowFeature(featureId: Int) = superDelegate.hasWindowFeature(featureId)
+
+    override fun startSupportActionMode(
+        callback: ActionMode.Callback
+    ) = superDelegate.startSupportActionMode(callback)
+
+    override fun installViewFactory() = superDelegate.installViewFactory()
+
+    override fun createView(
+        parent: View?, name: String?, context: Context, attrs: AttributeSet
+    ): View? = superDelegate.createView(parent, name, context, attrs)
+
+    override fun setHandleNativeActionModesEnabled(enabled: Boolean) {
+        superDelegate.isHandleNativeActionModesEnabled = enabled
+    }
+
+    override fun isHandleNativeActionModesEnabled() = superDelegate.isHandleNativeActionModesEnabled
+
+    override fun onSaveInstanceState(outState: Bundle?) = superDelegate.onSaveInstanceState(
+        outState
+    )
+
+    override fun applyDayNight() = superDelegate.applyDayNight()
+
+    @RequiresApi(17)
+    override fun setLocalNightMode(mode: Int) {
+        superDelegate.localNightMode = mode
+    }
+
+    override fun getLocalNightMode() = superDelegate.localNightMode
+}

--- a/philology/src/main/java/com/jcminarro/philology/PhilologyAppCompatDelegateHolder.kt
+++ b/philology/src/main/java/com/jcminarro/philology/PhilologyAppCompatDelegateHolder.kt
@@ -1,15 +1,17 @@
 package com.jcminarro.philology
 
+import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.app.BaseContextWrappingDelegate
-import io.github.inflationx.viewpump.ViewPumpContextWrapper
 
 class PhilologyAppCompatDelegateHolder {
 
     private var baseContextWrappingDelegate: AppCompatDelegate? = null
 
-    fun getDelegate(superDelegate: AppCompatDelegate) = baseContextWrappingDelegate
-        ?: BaseContextWrappingDelegate(superDelegate) { context ->
-            ViewPumpContextWrapper.wrap(Philology.wrap(context))
-        }.apply { baseContextWrappingDelegate = this }
+    fun getDelegate(
+        superDelegate: AppCompatDelegate,
+        onAttachBaseContext: (Context) -> Context
+    ) = baseContextWrappingDelegate ?: BaseContextWrappingDelegate(
+        superDelegate, onAttachBaseContext
+    ).apply { baseContextWrappingDelegate = this }
 }

--- a/philology/src/main/java/com/jcminarro/philology/PhilologyAppCompatDelegateHolder.kt
+++ b/philology/src/main/java/com/jcminarro/philology/PhilologyAppCompatDelegateHolder.kt
@@ -1,0 +1,15 @@
+package com.jcminarro.philology
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.app.BaseContextWrappingDelegate
+import io.github.inflationx.viewpump.ViewPumpContextWrapper
+
+class PhilologyAppCompatDelegateHolder {
+
+    private var baseContextWrappingDelegate: AppCompatDelegate? = null
+
+    fun getDelegate(superDelegate: AppCompatDelegate) = baseContextWrappingDelegate
+        ?: BaseContextWrappingDelegate(superDelegate) { context ->
+            ViewPumpContextWrapper.wrap(Philology.wrap(context))
+        }.apply { baseContextWrappingDelegate = this }
+}

--- a/sample/src/main/java/com/jcminarro/philology/sample/MainActivity.kt
+++ b/sample/src/main/java/com/jcminarro/philology/sample/MainActivity.kt
@@ -6,13 +6,17 @@ import android.text.TextWatcher
 import android.widget.EditText
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import com.jcminarro.philology.Philology
 import com.jcminarro.philology.PhilologyAppCompatDelegateHolder
 import com.jcminarro.sample.R
+import io.github.inflationx.viewpump.ViewPumpContextWrapper
 
 class MainActivity : AppCompatActivity() {
 
     private val delegateHolder = PhilologyAppCompatDelegateHolder()
-    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate())
+    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate()) {
+        ViewPumpContextWrapper.wrap(Philology.wrap(it))
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/sample/src/main/java/com/jcminarro/philology/sample/MainActivity.kt
+++ b/sample/src/main/java/com/jcminarro/philology/sample/MainActivity.kt
@@ -1,21 +1,18 @@
 package com.jcminarro.philology.sample
 
-import android.content.Context
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.widget.EditText
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import com.jcminarro.philology.Philology
+import com.jcminarro.philology.PhilologyAppCompatDelegateHolder
 import com.jcminarro.sample.R
-import io.github.inflationx.viewpump.ViewPumpContextWrapper
 
 class MainActivity : AppCompatActivity() {
 
-    override fun attachBaseContext(newBase: Context) {
-        super.attachBaseContext(ViewPumpContextWrapper.wrap(Philology.wrap(newBase)))
-    }
+    private val delegateHolder = PhilologyAppCompatDelegateHolder()
+    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate())
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
This PR fixes #23 and #35.
Increased AppCompat version to 1.2.0 and adjusted the context wrapping based on changes described in this [answer](https://stackoverflow.com/a/58004553/218473).

### Changes
Instead of the old approach with override `attachBaseContext` from Activity - declare `PhilologyAppCompatDelegateHolder` in BaseActivity and supply the right delegate for `androidx.appcompat.app.AppCompatActivity#getDelegate` method:

```kotlin
    private val delegateHolder = PhilologyAppCompatDelegateHolder()
    override fun getDelegate() = delegateHolder.getDelegate(super.getDelegate()) {
        ViewPumpContextWrapper.wrap(Philology.wrap(it))
    }
```

The wrapped context will be reused inside activity on each `getDelegate` call.

**Note**: 
⚠️ I've pinpointed CircleCi image to the latest successful docker image build before [Update Java from v8 to v11. (#500)](https://github.com/circleci/circleci-images/commit/d7d7e3a357102e363c6d5c04b3c2774d58dd2d70) since it's incompatible with current `Robolectric` version

### How to test
1. Run the sample app (updated to AppCompat ver. 1.2.0)
2. `Philology` should replace the text in the sample app based on the device locale.